### PR TITLE
app: use plain domain for PRODUCTION_DOMAIN

### DIFF
--- a/roles/app/templates/project/managed.py
+++ b/roles/app/templates/project/managed.py
@@ -16,7 +16,7 @@ class CommunityProdSettings(CommunityBaseSettings):
 
     """Settings for local development"""
 
-    PRODUCTION_DOMAIN = 'dashboard.{{ rtd_domain }}'
+    PRODUCTION_DOMAIN = '{{ rtd_domain }}'
     USE_SUBDOMAIN = False
     PUBLIC_DOMAIN = '{{ PUBLIC_DOMAIN }}'
     PUBLIC_API_URL = '{{ PUBLIC_API_URL }}'


### PR DESCRIPTION
As we don't even have a dns entry for dashboard.