### PR TITLE
Use full dotted path to docsitalia to make easier to user from manage.py

### DIFF
--- a/roles/app/templates/project/managed.py
+++ b/roles/app/templates/project/managed.py
@@ -110,8 +110,8 @@ class CommunityProdSettings(CommunityBaseSettings):
     # Override classes
     CLASS_OVERRIDES = {
         'readthedocs.builds.syncers.Syncer': 'readthedocs.builds.syncers.LocalSyncer',
-        'readthedocs.core.resolver.Resolver': 'docsitalia.resolver.ItaliaResolver',
-        'readthedocs.oauth.services.GitHubService': 'docsitalia.oauth.services.github.DocsItaliaGithubService',
+        'readthedocs.core.resolver.Resolver': 'readthedocs.docsitalia.resolver.ItaliaResolver',
+        'readthedocs.oauth.services.GitHubService': 'readthedocs.docsitalia.oauth.services.github.DocsItaliaGithubService',
     }
 
     # Email


### PR DESCRIPTION
gunicorn configuration already setup the pythonpath so that path without `readthedocs` works
But when runnin commands from console, it's a change we always need to remember
There is no real reason to keep the path the old way