### PR TITLE
WIP Fix build by using proper SLUMBER_API_HOST

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -10,7 +10,7 @@ worker_hosts: 'docs'
 es_hosts: 'localhost'
 # comma separated list of hostnames for the different roles
 app_hosts: 'docs'
-api_host: 'localhost:8002'
+api_host: '{{ rtd_proto }}://{{ rtd_domain }}'
 db_host: 'localhost'
 
 DEBUG: True

--- a/roles/app/templates/project/managed.py
+++ b/roles/app/templates/project/managed.py
@@ -94,7 +94,7 @@ class CommunityProdSettings(CommunityBaseSettings):
     # eg: FILE_SINCER = 'readthedocs.builds.syncers.*' (likely RemoteSyncer)
     MULTIPLE_APP_SERVERS = '{{ app_hosts }}'.split(',')
     MULTIPLE_BUILD_SERVERS = '{{ worker_hosts }}'.split(',')
-    SLUMBER_API_HOST = 'http://{{ api_host }}'
+    SLUMBER_API_HOST = '{{ api_host }}'
     SLUMBER_USERNAME = '{{ SLUMBER_USERNAME }}'
     SLUMBER_PASSWORD = '{{ SLUMBER_PASSWORD }}'
     SYNC_USER = '{{ rtd_user }}'

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -26,7 +26,7 @@
     worker_hosts: 'localhost'
     es_hosts: 'localhost'
     app_hosts: 'localhost'
-    api_host: 'localhost'
+    api_host: 'http://localhost'
     db_host: ''
     db_pwd: ''
 


### PR DESCRIPTION
The api_host used in SLUMBER_API_HOST needs to point to the
proxied instance otherwise it fails:
slumber.exceptions.HttpNotFoundError: Client Error 404: http://localhost:8002/api/v2/project/29/

And possibly does not regress d0ff2e435a19c1535dbdd886ed1e512374d8fedd
which fixed the build because slumber client was not following
nginx http -> https redirect.