### PR TITLE
Force install pinned ES version

### DIFF
--- a/roles/es/defaults/main.yml
+++ b/roles/es/defaults/main.yml
@@ -1,2 +1,2 @@
 es_legacy: 0
-es_version: 5.6.9
+es_version: 5.6.10

--- a/roles/es/tasks/main.yml
+++ b/roles/es/tasks/main.yml
@@ -26,7 +26,7 @@
      - setup
 
 - name: ES packages
-  apt: pkg={{ item }} state=present update_cache=true install_recommends=no
+  apt: pkg={{ item }} state=present update_cache=true install_recommends=no force=yes
   when: es == 1
   with_items:
     - elasticsearch={{ es_version }}


### PR DESCRIPTION
If currently installed ES version is newer than pinned, apt ansible module
exists with error unless `force` argument is set.

This commit set it to 1 and also bumps es version to the last 5.6.x version