### PR TITLE
Fix regexp to pass path to django

### DIFF
--- a/roles/app/templates/nginx/sites-available/readthedocs-main.conf
+++ b/roles/app/templates/nginx/sites-available/readthedocs-main.conf
@@ -51,7 +51,7 @@ server {
 
     # These are django urls prefixes that might be swallowed by the static serving
     # regexp below
-    location ~* /(accounts|admin|builds|dashboard|docs|docsitalia|notifications|profiles|projects|wipe|converti) {
+    location ~* /(accounts|admin|builds|dashboard|docs|docsitalia|notifications|profiles|projects|wipe|converti)/ {
         include /etc/nginx/fallback_defaults;
     }
 


### PR DESCRIPTION
Fix an error which caused requests to be passed to django instead of serving file from nginx