### PR TITLE
nginx: pass X-Forwarded-Proto when proxying https

### DIFF
--- a/roles/app/templates/nginx/proxy_defaults
+++ b/roles/app/templates/nginx/proxy_defaults
@@ -3,3 +3,4 @@ proxy_set_header Host $host;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Host $host;
+proxy_set_header X-Forwarded-Proto https;

--- a/roles/app/templates/project/managed.py
+++ b/roles/app/templates/project/managed.py
@@ -114,7 +114,7 @@ class CommunityProdSettings(CommunityBaseSettings):
     # Don't require email verification, but send verification email.
     ACCOUNT_EMAIL_VERIFICATION = 'optional'
     SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
-    # SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
     REPO_LOCK_SECONDS = 300
     DONT_HIT_DB = False
 


### PR DESCRIPTION
On https pass the protocol down to django and configure django to use that info to decide the schema. 