### PR TITLE
app: fixup nginx regexp for django applications

### DIFF
--- a/roles/app/templates/nginx/sites-available/readthedocs-main.conf
+++ b/roles/app/templates/nginx/sites-available/readthedocs-main.conf
@@ -52,7 +52,7 @@ server {
 
     # These are django urls prefixes that might be swallowed by the static serving
     # regexp below
-    location ~* /(accounts|admin|builds|dashboard|docs|docsitalia|notifications|profiles|projects|wipe|converti)/ {
+    location ~* ^/(accounts|admin|builds|dashboard|docs|docsitalia|notifications|profiles|projects|wipe|converti)/ {
         include /etc/nginx/fallback_defaults;
     }
 


### PR DESCRIPTION
We should match the django path app only at the start of path.

Fixed serving the following url:
/italia/piano-triennale-per-linformatica-nella-pubblica-amministrazione/
censimento-ict/it/bozza/docs/circolari/2017113005.html

where docs matched the django app path :)