### PR TITLE
app: add missing vew version permission to api consumer user

### DIFF
--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -159,12 +159,21 @@
   tags:
      - deploy
 
-- name: create slumber api consumer django user with proper permissions if not available
+- name: create slumber api consumer django user if not available
   become_user: "{{ rtd_user }}"
   command: "{{ rtd_virtualenv }}/bin/python {{ rtd_root }}/manage.py shell --settings=readthedocs.settings.managed"
   args:
-    stdin: "from django.contrib.auth.models import User, Permission; u = User.objects.create_user('{{ SLUMBER_USERNAME }}', password='{{ SLUMBER_PASSWORD }}', is_staff=True); p = Permission.objects.get(codename='view_project', content_type__app_label='projects'); u.user_permissions.add(p)"
+    stdin: "from django.contrib.auth.models import User; User.objects.create_user('{{ SLUMBER_USERNAME }}', password='{{ SLUMBER_PASSWORD }}', is_staff=True);"
   when: app == 1 and 'False' in build_user_available.stdout
+  tags:
+     - deploy
+
+- name: add proper permission to slumber api consumer django user
+  become_user: "{{ rtd_user }}"
+  command: "{{ rtd_virtualenv }}/bin/python {{ rtd_root }}/manage.py shell --settings=readthedocs.settings.managed"
+  args:
+    stdin: "from django.contrib.auth.models import User, Permission; u = User.objects.get(username='{{ SLUMBER_USERNAME }}'); p = Permission.objects.get(codename='view_project', content_type__app_label='projects'); u.user_permissions.add(p); p = Permission.objects.get(codename='view_version', content_type__app_label='builds'); u.user_permissions.add(p);"
+  when: app == 1
   tags:
      - deploy
 


### PR DESCRIPTION
While at it decouple the user creation from the permissions
granting. We want to create the user once but better
fixup permissions at each deploy.

Fixes:
```
ERROR An unhandled exception was raised during build setup [readthedocs.projects.tasks:329]
Traceback (most recent call last):
  File "/readthedocs/projects/tasks.py", line 314, in run
    self.version = self.get_version(self.project, version_pk)
  File "/readthedocs/projects/tasks.py", line 84, in get_version
    version_data = api_v2.version(version_pk).get()
  File "/virtualenv/lib/python3.5/site-packages/slumber/__init__.py", line 155, in get
    resp = self._request("GET", params=kwargs)
  File "/virtualenv/lib/python3.5/site-packages/slumber/__init__.py", line 101, in _request
    raise exception_class("Client Error %s: %s" % (resp.status_code, url), response=resp, content=resp.content)
slumber.exceptions.HttpNotFoundError: Client Error 404: http://localhost:8002/api/v2/version/1025/
```