### PR TITLE
Allow django to serve private docs

### DIFF
--- a/roles/app/templates/project/managed.py
+++ b/roles/app/templates/project/managed.py
@@ -15,7 +15,8 @@ _redis = {
 class CommunityProdSettings(CommunityBaseSettings):
 
     """Settings for local development"""
-
+    SERVE_DOCS = ['private']
+    PYTHON_MEDIA = True
     PRODUCTION_DOMAIN = '{{ rtd_domain }}'
     USE_SUBDOMAIN = False
     PUBLIC_DOMAIN = '{{ PUBLIC_DOMAIN }}'


### PR DESCRIPTION
We need to let Django serve the builded docs when a document is private as described here:

https://github.com/italia/docs.italia.it/blob/italia-2.3.13/readthedocs/core/views/serve.py#L24