### PR TITLE
Fix greedy regexps which caused issues in corner cases

### DIFF
--- a/roles/app/templates/nginx/sites-available/readthedocs-main.conf
+++ b/roles/app/templates/nginx/sites-available/readthedocs-main.conf
@@ -58,14 +58,19 @@ server {
 
     # document serving
     location ~* ^/(?P<publisher>[^/]+)/(?P<project>[^/]+)/(?P<document>[^/]+)/ {
-        # first submatch redirect to the default language / version
+        # first/second submatch redirect to the default language / version by hitting a redirect view on django
         location ~* ^/(?P<publisher>[^/]+)/(?P<project>[^/]+)/(?P<document>[^/]+)/$ {
             add_header X-Redirct-From Nginx;
             add_header X-Deity docs;
-            rewrite ^ https://{{ rtd_domain }}/$publisher/$project/$document/{{ rtd_default_language }}/{{ rtd_default_version }}/;
+            include /etc/nginx/fallback_defaults;
+        }
+        location ~* ^/(?P<publisher>[^/]+)/(?P<project>[^/]+)/(?P<document>[^/]+)/(?P<lang>\w\w)/$ {
+            add_header X-Redirct-From Nginx;
+            add_header X-Deity docs;
+            include /etc/nginx/fallback_defaults;
         }
 
-        # second submatch serves any project file directly from the local disk. path group is needed to build the
+        # third submatch serves any project file directly from the local disk. path group is needed to build the
         # try_files argument because we can't use $uri as we need to remove the prefix up to project
         location ~* ^/(?P<publisher>[^/]+)/(?P<project>[^/]+)/(?P<document>[^/]+)/(?P<lang>\w\w)/(?P<version>[^/]+)/(?P<path>.*)(/?)$ {
             root /home/docs/docs.italia.it/public_web_root/;

--- a/roles/app/templates/nginx/sites-available/readthedocs-main.conf
+++ b/roles/app/templates/nginx/sites-available/readthedocs-main.conf
@@ -39,7 +39,7 @@ server {
         add_header X-Deity docs;
     }
 
-    location ~* /(api|build|bitbucket|github) {
+    location ~* ^/(api|build|bitbucket|github) {
         proxy_pass http://{{ rtd_app_server }}:8002;
         include /etc/nginx/proxy_defaults;
         access_log {{ nginx_logs }}/readthedocs-api.log host;
@@ -67,9 +67,9 @@ server {
 
         # second submatch serves any project file directly from the local disk. path group is needed to build the
         # try_files argument because we can't use $uri as we need to remove the prefix up to project
-        location ~* ^/(?P<publisher>[^/]+)/(?P<project>[^/]+)/(?P<document>[^/]+)/(?P<lang>\w\w)/(?P<version>[^/]+)/(?P<path>.*)$ {
+        location ~* ^/(?P<publisher>[^/]+)/(?P<project>[^/]+)/(?P<document>[^/]+)/(?P<lang>\w\w)/(?P<version>[^/]+)/(?P<path>.*)(/?)$ {
             root /home/docs/docs.italia.it/public_web_root/;
-            try_files /$document/$lang/$version/$path /$document/$lang/$version/index.html =404;
+            try_files /$document/$lang/$version/$path /$document/$lang/$version/$path/index.html /$document/$lang/$version/index.html =404;
         }
     }
 


### PR DESCRIPTION
* fix 404 on files named api.html
* fix static files not loaded if the path ends with / Fix #80 
* correctly returns 404 for non existing pages Fix #66 
* Fix italia/docs.italia.it#218
* redirect unversioned / unlanguaged document urls to a django view to redirect to the canonical url italia/docs.italia.it#225 Needed by italia/docs.italia.it#226