### PR TITLE
Redirect custom per nginx

### DIFF
--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -240,6 +240,7 @@
     - nginx.conf
     - conf.d/general-configuration.conf
     - sites-available/readthedocs-main.conf
+    - snippets/docs-redirects.conf
     - fallback_defaults
     - proxy_defaults
   notify: reload nginx

--- a/roles/app/templates/nginx/sites-available/readthedocs-main.conf
+++ b/roles/app/templates/nginx/sites-available/readthedocs-main.conf
@@ -152,6 +152,8 @@ server {
     ## verify chain of trust of OCSP response using Root CA and Intermediate certs
     ssl_trusted_certificate /etc/ssl/private/trusted_ocsp_certificate.pem;
     {% endif %}
+
+    include /etc/nginx/snippets/docs-redirects.conf;
 }
 
 {% if rtd_proto == 'https' %}

--- a/roles/app/templates/nginx/snippets/docs-redirects.conf
+++ b/roles/app/templates/nginx/snippets/docs-redirects.conf
@@ -1,0 +1,4 @@
+# Document "Piano Triennale" - move permanently version "stabile" to version "2017-2019"
+# This is to prevent broken links pointing to version "stabile"
+# The version "stabile" needs to be deactivated
+rewrite ^/italia/piano-triennale-ict/pianotriennale-ict-doc/it/stabile/(.*)$ /italia/piano-triennale-ict/pianotriennale-ict-doc/it/2017-2019/$1 permanent;


### PR DESCRIPTION
Le funzionalità di [redirect di rtd](https://docs.readthedocs.io/en/stable/user-defined-redirects.html) non funzionano su Docs Italia. Probabilmente perché è completamente cambiata la struttura degli URL.

L'introduzione di regole custom si rende necessaria per evitare broken link esterni nel caso di disattivazione di versioni oppure nel caso in cui in una nuova versione `stabile` siano cambiati i path rispetto alla precedente.

Questa PR introduce una nuova regola custom per fare redirect dalla versione `stabile` del documento "Piano triennale" alla versione `2017-2019` che corrisponde a quella diffusa con il path `stabile`.

**Da deployare solo dopo aver creato la versione `2017-2019` e disattivato la `stabile`.**