### PR TITLE
Fix downloading backup scripts

### DIFF
--- a/README.it.rst
+++ b/README.it.rst
@@ -180,6 +180,7 @@ A parte quelle relative alla configurazione del database condivise con il role `
 * ``sql_backup_history[=30]``: numero massimo di giorni per i file di backup
 * ``sql_backup_dir[=/var/local/backup]``: directory locale del server dove archiviare i backup
 * ``sql_backup_script[=/usr/local/sbin/backup_sql.sh]``: percorso dello script di backup
+* ``backup_delete[=]``: se valorizzato a ``delete`` gli script di backup cancellano i backup più vecchi di ``sql_backup_history``.
 
 Archiviazione remota
 ********************

--- a/README.rst
+++ b/README.rst
@@ -178,6 +178,7 @@ The ``backup`` role provides dedicated variables :
 * ``sql_backup_history[=30]``: oldest backup to be kept on the server
 * ``sql_backup_dir[=/var/local/backup]``: local server directory to store backup files
 * ``sql_backup_script[=/usr/local/sbin/backup_sql.sh]``: backup script path
+* ``backup_delete[=]``: if set to ``delete``, makes backup scripts delete backups older than ``sql_backup_history``.
 
 ====
 TODO

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -2,3 +2,4 @@ backup_history: 30
 backup_dir: /var/local/backup
 backup_sql_script: /usr/local/sbin/backup_sql.sh
 backup_ssl_script: /usr/local/sbin/backup_ssl.sh
+backup_delete:

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -69,7 +69,7 @@
      - setup
 
 - name: run backup
-  command: "{{ backup_sql_script }}"
+  command: "{{ backup_sql_script }} {{ backup_delete }}"
   register: backup_sql_file
   when: sql == 1
   tags:
@@ -92,7 +92,7 @@
      - backup
 
 - name: run SSL backup
-  command: "{{ backup_ssl_script }}"
+  command: "{{ backup_ssl_script }} {{ backup_delete }}"
   register: backup_ssl_file
   when: app == 1
   tags:

--- a/roles/backup/templates/backup_sql.sh
+++ b/roles/backup/templates/backup_sql.sh
@@ -5,7 +5,9 @@ set -e
 DATE=`date +"%Y%m%d-%H%M%S"`
 BACKUP_FILE="{{ backup_dir }}/docs-${DATE}.sql.gz"
 
-find {{ backup_dir }} -ctime +{{ backup_history }}
+if [[ "$1" == "delete" ]]; then
+  find {{ backup_dir }} -ctime +{{ backup_history }} -delete
+fi
 
 pg_dump -h {{ rtd_db_host|default('localhost', true) }} -p {{ rtd_db_port }} -U {{ rtd_db_user }} {{ rtd_db_name }} | gzip -9c > $BACKUP_FILE
 

--- a/roles/backup/templates/backup_ssl.sh
+++ b/roles/backup/templates/backup_ssl.sh
@@ -5,7 +5,9 @@ set -e
 DATE=`date +"%Y%m%d-%H%M%S"`
 BACKUP_FILE="{{ backup_dir }}/docs-ssl-${DATE}.tar.gz"
 
-find {{ backup_dir }} -ctime +{{ backup_history }}
+if [[ "$1" == "delete" ]]; then
+  find {{ backup_dir }} -ctime +{{ backup_history }} -delete
+fi
 
 cd /etc
 tar -czf ${BACKUP_FILE} letsencrypt


### PR DESCRIPTION
Do not print the list of existing files in stdout as it's used to detect the file to download in the ansible role

The `find` was meant anyway to be used with `-delete` arg to remove old backups