### PR TITLE
Fix double configuration directive

### DIFF
--- a/roles/app/templates/nginx/conf.d/general-configuration.conf
+++ b/roles/app/templates/nginx/conf.d/general-configuration.conf
@@ -33,4 +33,3 @@ tcp_nodelay on;
 keepalive_timeout 65;
 types_hash_max_size 2048;
 client_max_body_size 100M;
-server_names_hash_bucket_size 128;


### PR DESCRIPTION
The directive is already set in `nginx.conf`