### PR TITLE
Fix 404 page path

### DIFF
--- a/roles/app/templates/nginx/sites-available/readthedocs-main.conf
+++ b/roles/app/templates/nginx/sites-available/readthedocs-main.conf
@@ -17,7 +17,7 @@ server {
 
     error_page    404 /404-static.html;
     location /404-static.html {
-        root {{ rtd_root }}/media/html;
+        root {{ rtd_root }}/media/html/404;
         break;
     }
 


### PR DESCRIPTION
Il template della 404 è in una sottodirectory di `media/html`

Ref italia/docs.italia.it#262