### PR TITLE
Restore default TAGGIT_TAGS_FROM_STRING

### DIFF
--- a/roles/app/templates/project/local_settings.py
+++ b/roles/app/templates/project/local_settings.py
@@ -45,6 +45,7 @@ class CommunityProdSettings(CommunityBaseSettings):
     SECRET_KEY = '{{ SECRET_KEY }}'
     DEFAULT_FROM_EMAIL = '{{ DEFAULT_FROM_EMAIL }}'
     SESSION_COOKIE_DOMAIN = '{{ rtd_domain }}'
+    TAGGIT_TAGS_FROM_STRING = 'taggit.utils._parse_tags'
 
     DOCROOT = os.path.join(DOCS_BASE, 'user_builds')
     UPLOAD_ROOT = os.path.join(DOCS_BASE, 'user_uploads')


### PR DESCRIPTION
Setting has been customized by RTD but we want to keep tags unslugified

Linked to https://github.com/italia/docs.italia.it/pull/471/