### PR TITLE
Delete backups older than 30 days by default.

### DIFF
--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -2,4 +2,4 @@ backup_history: 30
 backup_dir: /var/local/backup
 backup_sql_script: /usr/local/sbin/backup_sql.sh
 backup_ssl_script: /usr/local/sbin/backup_ssl.sh
-backup_delete:
+backup_delete: delete


### PR DESCRIPTION
(this is already in production)